### PR TITLE
Add support for XZ compression, fixes #1

### DIFF
--- a/PySquashfsImage/PySquashfsImage.py
+++ b/PySquashfsImage/PySquashfsImage.py
@@ -732,7 +732,7 @@ class SquashFsImage(_Squashfs_commons):
 		while ofs<len(table) :
 			entry = _Squashfs_fragment_entry()
 			ofs = entry.fill(table,ofs)
-			entry.fragment = self.read_block(myfile,entry.start_block) [0]
+			entry.fragment = self.read_data_block(myfile,entry.start_block,entry.size)
 			self.fragment_table.append(entry)
 			
 	def read_fragment(self,fragment):

--- a/PySquashfsImage/PySquashfsImage.py
+++ b/PySquashfsImage/PySquashfsImage.py
@@ -27,6 +27,7 @@ ZLIB_COMPRESSION        = 1
 LZMA_COMPRESSION        = 2
 LZO_COMPRESSION         = 3
 XZ_COMPRESSION          = 4
+LZ4_COMPRESSION         = 5
 
 SQUASHFS_MAJOR          = 4
 SQUASHFS_MINOR          = 0
@@ -151,7 +152,16 @@ class _ZlibCompressor:
 		import zlib
 		return zlib.decompress(src)
 
-_compressors = ( _Compressor(), _ZlibCompressor() )
+class _XZCompressor:
+	def __init__(self):
+		self.supported = XZ_COMPRESSION
+		self.name="xz"
+		
+	def uncompress(self, src):
+		import lzma
+		return lzma.decompress(src)
+
+_compressors = ( _Compressor(), _ZlibCompressor(), _XZCompressor() )
 
 if sys.version_info[0] < 3: pyVersionTwo = True
 else: pyVersionTwo = False


### PR DESCRIPTION
Fixed a little bug in commit 1 that made it possible to add XZ compression, no clue why lzma is the only decompressor that complained about the garbage data and the others didn't.

Kinda forgot about this because I've implemented the stuff I needed myself here: https://github.com/BotoX/Dahua-Firmware-Mod-Kit/blob/master/SquashFS.py
