### PR TITLE
Symlink fixup

### DIFF
--- a/PySquashfsImage/PySquashfsImage.py
+++ b/PySquashfsImage/PySquashfsImage.py
@@ -826,8 +826,7 @@ class SquashFsImage(_Squashfs_commons):
 			i.xattr = header.xattr
 		elif header.inode_type==SQUASHFS_SYMLINK_TYPE or header.inode_type==SQUASHFS_LSYMLINK_TYPE: 
 			header.symlink_header(self.inode_table,block_ptr)
-			i.symlink = self.inode_table[block_ptr+24:block_ptr+24+header.symlink_size+1]
-			i.symlink[header.symlink_size] = '\0'
+			i.symlink = self.inode_table[block_ptr+24:block_ptr+24+header.symlink_size+1] + b'\0'
 			i.data = header.symlink_size
 			if header.inode_type == SQUASHFS_LSYMLINK_TYPE:
 				i.xattr = self.makeBufInteger(self.inode_table,block_ptr + 24 + header.symlink_size, 4)
@@ -964,7 +963,7 @@ class SquashFsImage(_Squashfs_commons):
 			if objtype == SQUASHFS_DIR_TYPE :
 				self.pre_scan(parent_name, start_block, offset, parent)
 			else:
-				if objtype == SQUASHFS_FILE_TYPE or objtype == SQUASHFS_LREG_TYPE :
+				if objtype in [SQUASHFS_FILE_TYPE, SQUASHFS_LREG_TYPE, SQUASHFS_SYMLINK_TYPE, SQUASHFS_LSYMLINK_TYPE]:
 					i = self.read_inode(start_block, offset)
 					if self.created_inode[i.inode_number - 1] == None :
 						self.created_inode[i.inode_number - 1] = i

--- a/PySquashfsImage/PySquashfsImage.py
+++ b/PySquashfsImage/PySquashfsImage.py
@@ -834,7 +834,7 @@ class SquashFsImage(_Squashfs_commons):
 			i.xattr = header.xattr
 		elif header.inode_type==SQUASHFS_SYMLINK_TYPE or header.inode_type==SQUASHFS_LSYMLINK_TYPE: 
 			header.symlink_header(self.inode_table,block_ptr)
-			i.symlink = self.inode_table[block_ptr+24:block_ptr+24+header.symlink_size] + b'\0'
+			i.symlink = byt2str(self.inode_table[block_ptr+24:block_ptr+24+header.symlink_size])
 			i.data = header.symlink_size
 			if header.inode_type == SQUASHFS_LSYMLINK_TYPE:
 				i.xattr = self.makeBufInteger(self.inode_table,block_ptr + 24 + header.symlink_size, 4)

--- a/PySquashfsImage/PySquashfsImage.py
+++ b/PySquashfsImage/PySquashfsImage.py
@@ -599,15 +599,20 @@ class SquashedFile():
 
 	def isLink(self):
 		return self.hasAttribute(stat.S_IFLNK)
-		
+
 	def close(self):	
 		self.inode.image.close()
+
 	def getLength(self):
 		return self.inode.data
-		
+
 	def getName(self):
 		return self.name
-		
+
+	def getLink(self):
+		if self.inode==None:
+			return None
+		return self.inode.symlink
 
 class SquashFsImage(_Squashfs_commons):
 	def __init__(self,filepath=None,offset=None):
@@ -829,7 +834,7 @@ class SquashFsImage(_Squashfs_commons):
 			i.xattr = header.xattr
 		elif header.inode_type==SQUASHFS_SYMLINK_TYPE or header.inode_type==SQUASHFS_LSYMLINK_TYPE: 
 			header.symlink_header(self.inode_table,block_ptr)
-			i.symlink = self.inode_table[block_ptr+24:block_ptr+24+header.symlink_size+1] + b'\0'
+			i.symlink = self.inode_table[block_ptr+24:block_ptr+24+header.symlink_size] + b'\0'
 			i.data = header.symlink_size
 			if header.inode_type == SQUASHFS_LSYMLINK_TYPE:
 				i.xattr = self.makeBufInteger(self.inode_table,block_ptr + 24 + header.symlink_size, 4)
@@ -992,11 +997,11 @@ if __name__=="__main__":
 				print("FOLDER " + squashed_file.getPath())
 				for child in squashed_file.children:
 					if child.isFolder():
-						print("\t%-20s <dir>" % child.name)
+						print("\t%-60s  <dir> " % child.name)
 					elif child.isLink():
-						print("\t%-20s ->" % child.name)
+						print("\t%s -> %s" % (child.name,child.getLink()))
 					else:
-						print("\t%-20s %s" % (child.name,child.inode.data))
+						print("\t%-60s %8d" % (child.name,child.inode.data))
 			else:  
 				print(squashed_file.getContent())
 	else:

--- a/PySquashfsImage/PySquashfsImage.py
+++ b/PySquashfsImage/PySquashfsImage.py
@@ -592,10 +592,13 @@ class SquashedFile():
 			return False
 		return self.inode.hasAttribute(mask)
 		
-	def  isFolder(self):
+	def isFolder(self):
 		if self.parent==None : 
 			return True
-		return self.hasAttribute(stat.S_IFDIR)	
+		return self.hasAttribute(stat.S_IFDIR)
+
+	def isLink(self):
+		return self.hasAttribute(stat.S_IFLNK)
 		
 	def close(self):	
 		self.inode.image.close()
@@ -990,6 +993,8 @@ if __name__=="__main__":
 				for child in squashed_file.children:
 					if child.isFolder():
 						print("\t%-20s <dir>" % child.name)
+					elif child.isLink():
+						print("\t%-20s ->" % child.name)
 					else:
 						print("\t%-20s %s" % (child.name,child.inode.data))
 			else:  


### PR DESCRIPTION
It appears that PySquashfsImage doesn't currently support symlinks.

This change adds some support by ensuring that `read_inode` happens for both files and links.

To test this I used the current slack snap via: https://snapcraft.io/slack

Before:
```
$ python2 PySquashfsImage/PySquashfsImage.py slack_14.snap /lib/x86_64-linux-gnu
--------------/lib/x86_64-linux-gnu                              --------------
FOLDER /lib/x86_64-linux-gnu
	libbsd.so.0          <dir>
	libbsd.so.0.8.2      84976
	libdbus-1.so.3       84976
	libdbus-1.so.3.14.6  327216
	libexpat.so.1        327216
	libexpat.so.1.6.0    171056
	libglib-2.0.so.0     171056
	libglib-2.0.so.0.4800.2 1154768
	libjson-c.so.2       1154768
	libjson-c.so.2.0.0   48504
	libkeyutils.so.1     48504
	libkeyutils.so.1.5   18432
	libpcre.so.3         18432
	libpcre.so.3.13.2    460760
	libpng12.so.0        460760
	libpng12.so.0.54.0   156960
	libwrap.so.0         156960
	libwrap.so.0.7.6     39360
```

After:
```
$ python2 PySquashfsImage/PySquashfsImage.py slack_14.snap /lib/x86_64-linux-gnu
--------------/lib/x86_64-linux-gnu                              --------------
FOLDER /lib/x86_64-linux-gnu
	libbsd.so.0          ->
	libbsd.so.0.8.2      84976
	libdbus-1.so.3       ->
	libdbus-1.so.3.14.6  327216
	libexpat.so.1        ->
	libexpat.so.1.6.0    171056
	libglib-2.0.so.0     ->
	libglib-2.0.so.0.4800.2 1154768
	libjson-c.so.2       ->
	libjson-c.so.2.0.0   48504
	libkeyutils.so.1     ->
	libkeyutils.so.1.5   18432
	libpcre.so.3         ->
	libpcre.so.3.13.2    460760
	libpng12.so.0        ->
	libpng12.so.0.54.0   156960
	libwrap.so.0         ->
	libwrap.so.0.7.6     39360
```
And w.r.t the mounted snap on my filesystem:
```
$ ls -lah /snap/slack/14/lib/x86_64-linux-gnu/
total 2.4M
drwxr-xr-x 2 root root  441 May 22 12:59 .
drwxr-xr-x 3 root root   39 Sep 18  2018 ..
lrwxrwxrwx 1 root root   15 Jan 28  2016 libbsd.so.0 -> libbsd.so.0.8.2
-rw-r--r-- 1 root root  83K May 22 12:59 libbsd.so.0.8.2
lrwxrwxrwx 1 root root   19 Jan 13  2017 libdbus-1.so.3 -> libdbus-1.so.3.14.6
-rw-r--r-- 1 root root 320K May 22 12:59 libdbus-1.so.3.14.6
lrwxrwxrwx 1 root root   17 Jun 27  2017 libexpat.so.1 -> libexpat.so.1.6.0
-rw-r--r-- 1 root root 168K May 22 12:59 libexpat.so.1.6.0
lrwxrwxrwx 1 root root   23 Sep 18  2018 libglib-2.0.so.0 -> libglib-2.0.so.0.4800.2
-rw-r--r-- 1 root root 1.2M May 22 12:59 libglib-2.0.so.0.4800.2
lrwxrwxrwx 1 root root   18 Jan 13  2015 libjson-c.so.2 -> libjson-c.so.2.0.0
-rw-r--r-- 1 root root  48K May 22 12:59 libjson-c.so.2.0.0
lrwxrwxrwx 1 root root   18 Dec 11  2015 libkeyutils.so.1 -> libkeyutils.so.1.5
-rw-r--r-- 1 root root  18K May 22 12:59 libkeyutils.so.1.5
lrwxrwxrwx 1 root root   17 Mar 25  2016 libpcre.so.3 -> libpcre.so.3.13.2
-rw-r--r-- 1 root root 450K May 22 12:59 libpcre.so.3.13.2
lrwxrwxrwx 1 root root   18 Jul 11  2018 libpng12.so.0 -> libpng12.so.0.54.0
-rw-r--r-- 1 root root 154K May 22 12:59 libpng12.so.0.54.0
lrwxrwxrwx 1 root root   16 Jan 13  2014 libwrap.so.0 -> libwrap.so.0.7.6
-rw-r--r-- 1 root root  39K May 22 12:59 libwrap.so.0.7.6
```
```