### PR TITLE
Implement SquashedFile getMode as ls-style string

### DIFF
--- a/PySquashfsImage/PySquashfsImage.py
+++ b/PySquashfsImage/PySquashfsImage.py
@@ -190,7 +190,7 @@ class _Squashfs_commons():
 		if pyVersionTwo:
 			ret = 0
 			pwr = 1
-			for i in range(start,start+lenght):
+			for i in range(start,start+length):
 				ret += ((ord(buf[i])&0xFF)*pwr)
 				pwr *= 0x100
 			return ret
@@ -560,7 +560,7 @@ class SquashedFile():
 	def select(self,path):
 		if path == str2byt("/"):
 			path = str2byt("")
-		lpath = path.split(str2byt("/"))
+		lpath = path.split("/")
 		start = self
 		ofs = 0
 		if  lpath[0] == str2byt(""):
@@ -609,6 +609,29 @@ class SquashedFile():
 		if self.inode==None:
 			return None
 		return self.inode.symlink
+
+	def getMode(self):
+		ret = ['-'] * 10
+		if self.inode!=None:
+			if stat.S_IFMT(self.inode.mode) == stat.S_IFSOCK: ret[0] = 's'
+			if stat.S_IFMT(self.inode.mode) == stat.S_IFLNK:  ret[0] = 'l'
+			if stat.S_IFMT(self.inode.mode) == stat.S_IFBLK:  ret[0] = 'b'
+			if stat.S_IFMT(self.inode.mode) == stat.S_IFDIR:  ret[0] = 'd'
+			if stat.S_IFMT(self.inode.mode) == stat.S_IFCHR:  ret[0] = 'c'
+			if stat.S_IFMT(self.inode.mode) == stat.S_IFIFO:  ret[0] = 'p'
+
+			if (self.inode.mode & stat.S_IRUSR) == stat.S_IRUSR: ret[1] = 'r'
+			if (self.inode.mode & stat.S_IWUSR) == stat.S_IWUSR: ret[2] = 'w'
+			if (self.inode.mode & stat.S_IRGRP) == stat.S_IRGRP: ret[4] = 'r'
+			if (self.inode.mode & stat.S_IWGRP) == stat.S_IWGRP: ret[5] = 'w'
+			if (self.inode.mode & stat.S_IROTH) == stat.S_IROTH: ret[7] = 'r'
+			if (self.inode.mode & stat.S_IWOTH) == stat.S_IWOTH: ret[8] = 'w'
+
+			if (self.inode.mode & stat.S_IXUSR) == stat.S_IXUSR: ret[3] = 'x'
+			if (self.inode.mode & stat.S_IXGRP) == stat.S_IXGRP: ret[6] = 'x'
+			if (self.inode.mode & stat.S_IXOTH) == stat.S_IXOTH: ret[9] = 'x'
+
+		return ''.join(ret)
 
 class SquashFsImage(_Squashfs_commons):
 	def __init__(self,filepath=None,offset=None):
@@ -993,11 +1016,11 @@ if __name__=="__main__":
 				print("FOLDER " + squashed_file.getPath())
 				for child in squashed_file.children:
 					if child.isFolder():
-						print("\t%-60s  <dir> " % child.name)
+						print("\t%s %-60s  <dir> " % (child.getMode(),child.name))
 					elif child.isLink():
-						print("\t%s -> %s" % (child.name,child.getLink()))
+						print("\t%s %s -> %s" % (child.getMode(),child.name,child.getLink()))
 					else:
-						print("\t%-60s %8d" % (child.name,child.inode.data))
+						print("\t%s %-60s %8d" % (child.getMode(),child.name,child.inode.data))
 			else:  
 				print(squashed_file.getContent())
 	else:

--- a/PySquashfsImage/PySquashfsImage.py
+++ b/PySquashfsImage/PySquashfsImage.py
@@ -560,17 +560,18 @@ class SquashedFile():
 	def select(self,path):
 		if path == str2byt("/"):
 			path = str2byt("")
-		lpath = path.split("/")
+		lpath = [ str2byt(i) for i in path.split('/') ]
+		print(lpath)
 		start = self
 		ofs = 0
-		if  lpath[0] == str2byt(""):
+		if not lpath[0]:
 			ofs = 1
-			while start.parent!=None:
+			while start.parent:
 				start = start.parent
 		if ofs>=len(lpath):
 			return start
 		for child in start.children :
-			if child.name == lpath[ofs] :
+			if child.name == lpath[ofs]:
 				return child._lselect( lpath, ofs + 1 )
 		return None
 

--- a/PySquashfsImage/PySquashfsImage.py
+++ b/PySquashfsImage/PySquashfsImage.py
@@ -561,7 +561,6 @@ class SquashedFile():
 		if path == str2byt("/"):
 			path = str2byt("")
 		lpath = [ str2byt(i) for i in path.split('/') ]
-		print(lpath)
 		start = self
 		ofs = 0
 		if not lpath[0]:


### PR DESCRIPTION
For listing the permissions of files, links and directories.

Using the slack snap as an example:

```
$ python2 PySquashfsImage/PySquashfsImage.py slack_14.snap /lib/x86_64-linux-gnu
--------------/lib/x86_64-linux-gnu                              --------------
FOLDER /lib/x86_64-linux-gnu
	drwxr-xr-x libbsd.so.0          <dir>
	-rw-r--r-- libbsd.so.0.8.2      84976
	-rw-r--r-- libdbus-1.so.3       84976
	-rw-r--r-- libdbus-1.so.3.14.6  327216
	-rw-r--r-- libexpat.so.1        327216
	-rw-r--r-- libexpat.so.1.6.0    171056
	-rw-r--r-- libglib-2.0.so.0     171056
	-rw-r--r-- libglib-2.0.so.0.4800.2 1154768
	-rw-r--r-- libjson-c.so.2       1154768
	-rw-r--r-- libjson-c.so.2.0.0   48504
	-rw-r--r-- libkeyutils.so.1     48504
	-rw-r--r-- libkeyutils.so.1.5   18432
	-rw-r--r-- libpcre.so.3         18432
	-rw-r--r-- libpcre.so.3.13.2    460760
	-rw-r--r-- libpng12.so.0        460760
	-rw-r--r-- libpng12.so.0.54.0   156960
	-rw-r--r-- libwrap.so.0         156960
	-rw-r--r-- libwrap.so.0.7.6     39360
```

In comparison to the mounted filesystem:

```
$ ls -lah /snap/slack/14/lib/x86_64-linux-gnu/
total 2.4M
drwxr-xr-x 2 root root  441 May 22 12:59 .
drwxr-xr-x 3 root root   39 Sep 18  2018 ..
lrwxrwxrwx 1 root root   15 Jan 28  2016 libbsd.so.0 -> libbsd.so.0.8.2
-rw-r--r-- 1 root root  83K May 22 12:59 libbsd.so.0.8.2
lrwxrwxrwx 1 root root   19 Jan 13  2017 libdbus-1.so.3 -> libdbus-1.so.3.14.6
-rw-r--r-- 1 root root 320K May 22 12:59 libdbus-1.so.3.14.6
lrwxrwxrwx 1 root root   17 Jun 27  2017 libexpat.so.1 -> libexpat.so.1.6.0
-rw-r--r-- 1 root root 168K May 22 12:59 libexpat.so.1.6.0
lrwxrwxrwx 1 root root   23 Sep 18  2018 libglib-2.0.so.0 -> libglib-2.0.so.0.4800.2
-rw-r--r-- 1 root root 1.2M May 22 12:59 libglib-2.0.so.0.4800.2
lrwxrwxrwx 1 root root   18 Jan 13  2015 libjson-c.so.2 -> libjson-c.so.2.0.0
-rw-r--r-- 1 root root  48K May 22 12:59 libjson-c.so.2.0.0
lrwxrwxrwx 1 root root   18 Dec 11  2015 libkeyutils.so.1 -> libkeyutils.so.1.5
-rw-r--r-- 1 root root  18K May 22 12:59 libkeyutils.so.1.5
lrwxrwxrwx 1 root root   17 Mar 25  2016 libpcre.so.3 -> libpcre.so.3.13.2
-rw-r--r-- 1 root root 450K May 22 12:59 libpcre.so.3.13.2
lrwxrwxrwx 1 root root   18 Jul 11  2018 libpng12.so.0 -> libpng12.so.0.54.0
-rw-r--r-- 1 root root 154K May 22 12:59 libpng12.so.0.54.0
lrwxrwxrwx 1 root root   16 Jan 13  2014 libwrap.so.0 -> libwrap.so.0.7.6
-rw-r--r-- 1 root root  39K May 22 12:59 libwrap.so.0.7.6
```