### PR TITLE
Fix processing SQUASHFS_LREG_TYPE entries

### DIFF
--- a/PySquashfsImage/PySquashfsImage.py
+++ b/PySquashfsImage/PySquashfsImage.py
@@ -425,7 +425,7 @@ class _Inode_header(_Squashfs_commons):
 		self.fragment,offset = self.autoMakeBufInteger(buff,offset,4)
 		self.offset,offset = self.autoMakeBufInteger(buff,offset,4)
 		self.xattr,offset = self.autoMakeBufInteger(buff,offset,4)
-		self.block_list,offset = self.autoMakeBufInteger(buff,offset,4)
+		self.block_list=buff[offset:]
 		return offset
 
 	def dir_header (self,buff,offset):


### PR DESCRIPTION
When processing SQUASHFS_LREG_TYPE entries, excessive read of 4 bytes is made, which leads to detecting incorrect block offsets