### PR TITLE
New `pysquashfsimage` command, strings for names and paths, argparse

### DIFF
--- a/PySquashfsImage/PySquashfsImage.py
+++ b/PySquashfsImage/PySquashfsImage.py
@@ -1089,12 +1089,19 @@ class SquashFsImage(_Squashfs_commons):
 
 
 if __name__ == "__main__":
+    import argparse
     import sys
 
-    image = SquashFsImage(sys.argv[1])
+    parser = argparse.ArgumentParser()
+    parser.add_argument("file", help="squashfs filesystem")
+    parser.add_argument("paths", nargs='+', help="directories or files to print information about")
+    parser.add_argument("-V", "--version", action="version", version="%(prog)s v0.8.0")
+    args = parser.parse_args()
+
+    image = SquashFsImage(args.file)
     if len(sys.argv) > 1:
-        for i in range(2, len(sys.argv)):
-            sqashed_filename = sys.argv[i]
+        for path in args.paths:
+            sqashed_filename = path
             squashed_file = image.root.select(sqashed_filename)
             print("--------------%-50.50s --------------" % sqashed_filename)
             if squashed_file is None:

--- a/PySquashfsImage/PySquashfsImage.py
+++ b/PySquashfsImage/PySquashfsImage.py
@@ -1088,11 +1088,11 @@ class SquashFsImage(_Squashfs_commons):
         return mydir
 
 
-if __name__ == "__main__":
+def main():
     import argparse
     import sys
 
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(description="Print information about squashfs images.")
     parser.add_argument("file", help="squashfs filesystem")
     parser.add_argument("paths", nargs='+', help="directories or files to print information about")
     parser.add_argument("-V", "--version", action="version", version="%(prog)s v0.8.0")
@@ -1137,3 +1137,7 @@ if __name__ == "__main__":
                 with open(oname, "wb") as of:
                     of.write(content)
         image.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Examples:
 
 List all elements in the image:
 -------------------------------
-```
+```python
 from PySquashfsImage import SquashFsImage
 
 image = SquashFsImage('/path/to/my/image.img')
@@ -18,7 +18,7 @@ image.close()
 
 Print all files and folder with human readable path:
 ----------------------------------------------------
-```
+```python
 from PySquashfsImage import SquashFsImage
 
 image = SquashFsImage('/path/to/my/image.img')
@@ -29,7 +29,7 @@ image.close()
 
 Print only files:
 -----------------
-```
+```python
 from PySquashfsImage import SquashFsImage
 
 image = SquashFsImage('/path/to/my/image.img')
@@ -41,15 +41,14 @@ image.close()
 
 Save the content of a file:
 ---------------------------
-```
+```python
 from PySquashfsImage import SquashFsImage
 
 image = SquashFsImage('/path/to/my/image.img')
 for i in image.root.findAll():
-    if i.getName() == b'myfilename':
-        with open(b'/tmp/'+i.getName(),'wb') as f:
-            print(b'Saving original '+i.getPath().encode()+b' in /tmp/'+i.getName())
+    if i.getName() == 'myfilename':
+        with open('/tmp/' + i.getName(), 'wb') as f:
+            print('Saving original ' + i.getPath() + ' in /tmp/' + i.getName())
             f.write(i.getContent())
 image.close()
 ```
-

--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 PySquashfsImage is a lightweight library for reading squashfs image files in Python.
 It provides a way to read squashfs images header and to retrieve encapsulated binaries.
-It is compatible with Python2 and Python3.
+It is compatible with Python 2 and Python 3.
 
-Examples:
----------
+## Use as a library
 
-List all elements in the image:
+### List all elements in the image:
 -------------------------------
 ```python
 from PySquashfsImage import SquashFsImage
@@ -16,7 +15,7 @@ for i in image.root.findAll():
 image.close()
 ```
 
-Print all files and folder with human readable path:
+### Print all files and folder with human readable path:
 ----------------------------------------------------
 ```python
 from PySquashfsImage import SquashFsImage
@@ -27,7 +26,7 @@ for i in image.root.findAllPaths():
 image.close()
 ```
 
-Print only files:
+### Print only files:
 -----------------
 ```python
 from PySquashfsImage import SquashFsImage
@@ -39,7 +38,7 @@ for i in image.root.findAll():
 image.close()
 ```
 
-Save the content of a file:
+### Save the content of a file:
 ---------------------------
 ```python
 from PySquashfsImage import SquashFsImage
@@ -51,4 +50,29 @@ for i in image.root.findAll():
             print('Saving original ' + i.getPath() + ' in /tmp/' + i.getName())
             f.write(i.getContent())
 image.close()
+```
+
+## Use as a command
+
+```
+$ pysquashfsimage -h
+usage: pysquashfsimage [-h] [-V] file paths [paths ...]
+
+positional arguments:
+  file           squashfs filesystem
+  paths          directories or files to print information about
+
+options:
+  -h, --help     show this help message and exit
+  -V, --version  show program's version number and exit
+```
+
+For each path, if it is a directory it will print the mode and name of each
+contained file, with sizes and symlinks.
+
+If a path is a file, print its content.
+
+Example command:
+```
+$ pysquashfsimage myimage.img /bin /etc/passwd
 ```

--- a/setup.py
+++ b/setup.py
@@ -1,26 +1,35 @@
 #!/usr/bin/env python
 
-from setuptools import setup,find_packages
+from setuptools import setup, find_packages
+
+with open("README.md", 'r', encoding="utf8") as f:
+    long_description = f.read()
 
 setup(
-	name='PySquashfsImage',
-	version='0.7',
-	description='Squashfs image parser',
-	long_description='This package provides a way to read and extract squashfs images.',
-	author='Matteo Mattei; Nicola Ponzeveroni;',
-	author_email='info@matteomattei.com',
-	url='https://github.com/matteomattei/PySquashfsImage',
-	packages=find_packages(),
-	keywords = ["filesystem", "parser", "squash", "squashfs"],
-	classifiers = [
-		"Programming Language :: Python",
-		"Programming Language :: Python :: 3",
-		"Development Status :: 4 - Beta",
-		"Environment :: Other Environment",
-		"Intended Audience :: Developers",
-		"License :: OSI Approved :: GNU Library or Lesser General Public License (LGPL)",
-		"Operating System :: OS Independent",
-		"Topic :: Software Development :: Libraries :: Python Modules",
-		],
+    name='PySquashfsImage',
+    version='0.8.0',
+    description='Squashfs image parser',
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    author='Matteo Mattei; Nicola Ponzeveroni;',
+    author_email='info@matteomattei.com',
+    url='https://github.com/matteomattei/PySquashfsImage',
+    packages=find_packages(),
+    keywords=["filesystem", "parser", "squash", "squashfs"],
+    classifiers=[
+        "Development Status :: 4 - Beta",
+        "Environment :: Other Environment",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: GNU Library or Lesser General Public License (LGPL)",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 3",
+        "Topic :: Software Development :: Libraries :: Python Modules",
+    ],
+    entry_points={
+        "console_scripts": [
+            "pysquashfsimage = PySquashfsImage.PySquashfsImage:main",
+        ]
+    }
 )
-


### PR DESCRIPTION
- File names and paths are now instances of `str`, just like symlinks already were
- Replace `fill` by the `from_bytes` class method
- Further code simplifications
- Use `argparse` for command line parsing
- Add syntax highlighting to the readme
- Add `pysquashfsimage` command
- Bump version to 0.8.0 (because of added functionality according to semantic versioning)
- Add readme to `setup.py` so that it shows up on PyPI
- Add Python 2 classifier to `setup.py`

I would also like to mention that half of the code in the main (everything that's in the else) has always been unreachable. `len(sys.argv) <= 1` means there's no argument, so no image to open, and `sys.argv[1]` raises an `IndexError` anyway.