### PR TITLE
Do not throw on duplicate close calls

### DIFF
--- a/PySquashfsImage/__init__.py
+++ b/PySquashfsImage/__init__.py
@@ -128,7 +128,8 @@ class SquashFsImage(object):
         return cls(open(path, "rb"), offset)
 
     def close(self):
-        self._fd.close()
+        if self._fd is not None:
+            self._fd.close()
         self._fd = None
 
     def _read_super(self):


### PR DESCRIPTION
Especially because there is no `closed` test method, it should be possible to call `close` multiple times. Currently, this throws an exception:

```
PySquashfsImage/__init__.py", line 131, in close
    self._fd.close()
    ^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'close'
```